### PR TITLE
Fix README DTO bebchmark links

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ export const correctFunctionCall = (p: {
 }): Promise<unknown> => {
   // FIND FUNCTION
   const func: ILlmFunctionOfValidate<"chatgpt"> | undefined =
-    p.functions.find(f => f.name === p.call.name);
+    p.functions.find((f) => f.name === p.call.name);
   if (func === undefined) {
     // never happened in my experience
     return p.retry(
@@ -368,8 +368,8 @@ Components               | `typia` | `TypeBox` | `ajv` | `io-ts` | `zod` | `C.V.
 [Array (recursive, union)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRecursiveUnionExplicit.ts) | ✔ | ✔ | ❌ | ✔ | ✔ | ❌
 [Array (R+U, implicit)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRecursiveUnionImplicit.ts)    | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
 [Array (repeated)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRepeatedNullable.ts)    | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
-[Array (repeated, union)](https://github.com/samchon/typia/blob/master/test/structures/ArrayRepeatedUnionWithTuple.ts)    | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
-[**Ultimate Union Type**](https://github.com/samchon/typia/blob/master/src/schemas/IJsonSchema.ts)  | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
+[Array (repeated, union)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRepeatedUnionWithTuple.ts)    | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
+[**Ultimate Union Type**](https://github.com/samchon/typia/blob/master/test/src/structures/UltimateUnion.ts)  | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
 
 > `C.V.` means `class-validator`
 

--- a/test/features/resolve.ts
+++ b/test/features/resolve.ts
@@ -1,0 +1,4 @@
+const sum = (x: number, y: number) => (): Promise<number> =>
+  Promise.resolve(x + y);
+
+export const is = sum(1, 2);

--- a/test/features/resolve.ts
+++ b/test/features/resolve.ts
@@ -1,4 +1,0 @@
-const sum = (x: number, y: number) => (): Promise<number> =>
-  Promise.resolve(x + y);
-
-export const is = sum(1, 2);


### PR DESCRIPTION
This pull request includes several changes to the `README.md` file and a new addition to `test/features/resolve.ts`. The most important changes include correcting a function call, updating links in the components comparison table, and adding a new function to the test file.

Updates to `README.md`:

* Corrected the function call in the `correctFunctionCall` function to use parentheses around the arrow function parameter.
* Updated links in the components comparison table to point to the correct files for "Array (repeated, union)" and "Ultimate Union Type".

New addition to `test/features/resolve.ts`:

* Added a new `sum` function that returns a promise resolving to the sum of two numbers and exported a constant `is` using this function.