### PR TITLE
Add websocket interaction module

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ export const correctFunctionCall = (p: {
 }): Promise<unknown> => {
   // FIND FUNCTION
   const func: ILlmFunctionOfValidate<"chatgpt"> | undefined =
-    p.functions.find(f => f.name === p.call.name);
+    p.functions.find((f) => f.name === p.call.name);
   if (func === undefined) {
     // never happened in my experience
     return p.retry(
@@ -368,8 +368,8 @@ Components               | `typia` | `TypeBox` | `ajv` | `io-ts` | `zod` | `C.V.
 [Array (recursive, union)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRecursiveUnionExplicit.ts) | ✔ | ✔ | ❌ | ✔ | ✔ | ❌
 [Array (R+U, implicit)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRecursiveUnionImplicit.ts)    | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
 [Array (repeated)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRepeatedNullable.ts)    | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
-[Array (repeated, union)](https://github.com/samchon/typia/blob/master/test/structures/ArrayRepeatedUnionWithTuple.ts)    | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
-[**Ultimate Union Type**](https://github.com/samchon/typia/blob/master/src/schemas/IJsonSchema.ts)  | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
+[Array (repeated, union)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRepeatedUnionWithTuple.ts)    | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
+[**Ultimate Union Type**](https://github.com/samchon/typia/blob/master/test/src/structures/UltimateUnion.ts)  | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
 
 > `C.V.` means `class-validator`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrtnlabs/agent",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "lib/index.js",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -63,6 +63,7 @@
     "prettier": "^3.5.0",
     "rimraf": "^6.0.1",
     "rollup": "^4.29.1",
+    "tgrid": "^1.1.0",
     "ts-node": "^10.9.2",
     "ts-patch": "^3.3.0",
     "tstl": "^3.0.0",

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,3 +1,4 @@
+// TYPES
 export * from "./structures/IWrtnAgentConfig";
 export * from "./structures/IWrtnAgentContext";
 export * from "./structures/IWrtnAgentController";
@@ -10,9 +11,13 @@ export * from "./structures/IWrtnAgentProps";
 export * from "./structures/IWrtnAgentProvider";
 export * from "./structures/IWrtnAgentSystemPrompt";
 export * from "./structures/IWrtnAgentTokenUsage";
-
 export * from "./typings/WrtnAgentSource";
 
-export * from "./functional/createHttpLlmApplication";
+// REMOTE PROCEDURE CALL
+export * from "./rpc/IWrtnAgentRpcListener";
+export * from "./rpc/IWrtnAgentRpcService";
+export * from "./rpc/WrtnAgentRpcService";
 
+// FACADE CLASS
+export * from "./functional/createHttpLlmApplication";
 export * from "./WrtnAgent";

--- a/src/rpc/IWrtnAgentRpcListener.ts
+++ b/src/rpc/IWrtnAgentRpcListener.ts
@@ -1,0 +1,112 @@
+import { Primitive } from "typia";
+
+import { IWrtnAgentEvent } from "../structures/IWrtnAgentEvent";
+
+/**
+ * RPC interface of AI agent listener.
+ *
+ * `IWrtnAgentRpcListener` is an interface defining an AI agent listener
+ * provided from the client to server through the RPC (Remote Procedure Call)
+ * paradigm in the websocket protocol.
+ *
+ * It has defined the event listener functions of {@link IWrtnAgentEvent}
+ * types. If you skip some event typed functions' implementations,
+ * the skipped event would be ignored.
+ *
+ * Also, the event like listener functions of `IWrtnAgentRpcListener` type
+ * are remotely called when a client calls the
+ * {@link IWrtnAgentRpcService.conversate} function remotely, so that the
+ * server responses to the client by the event listener functions.
+ *
+ * You can connect to the WebSocket server of the AI agent like below:
+ *
+ * ```typescript
+ * import { IWrtnAgentRpcListener, IWrtnAgentRpcService } from "@wrtnlabs/agent";
+ * import { Driver, WebSocketConnector } from "tgrid";
+ *
+ * const connector: WebSocketConnector<
+ *   null,
+ *   IWrtnAgentRpcListener,
+ *   IWrtnAgentRpcService
+ * > = new WebSocketConnector(null, {
+ *   text: async (evt) => {
+ *     console.log(evt.role, evt.text);
+ *   },
+ *   describe: async (evt) => {
+ *     console.log("describer", evt.text);
+ *   },
+ * });
+ * await connector.connect("ws://localhost:3001");
+ *
+ * const driver: Driver<IWrtnAgentRpcService> = connector.getDriver();
+ * await driver.conversate("Hello, what you can do?");
+ * ```
+ *
+ * @author Samchon
+ */
+export interface IWrtnAgentRpcListener {
+  /**
+   * Describe the function executions' results.
+   *
+   * Inform description message of the function execution's results from
+   * the AI agent server to client.
+   *
+   * @param evt Event of a description of function execution results
+   */
+  describe(evt: Primitive<IWrtnAgentEvent.IDescribe>): Promise<void>;
+
+  /**
+   * Text conversation message.
+   *
+   * @param evt Event of a text conversation message
+   */
+  text(evt: Primitive<IWrtnAgentEvent.IText>): Promise<void>;
+
+  /**
+   * Select a function to call.
+   *
+   * Informs a selected function to call from the AI agent server to client.
+   *
+   * @param evt Event of selecting a function to call
+   */
+  select?(evt: Primitive<IWrtnAgentEvent.ISelect>): Promise<void>;
+
+  /**
+   * Cancel a function to call.
+   *
+   * Informs a canceling function to call from the AI agent server to client.
+   *
+   * @param evt Event of canceling a function to call
+   */
+  cancel?(evt: Primitive<IWrtnAgentEvent.ICancel>): Promise<void>;
+
+  /**
+   * Call a function.
+   *
+   * Informs a function calling from the AI agent server to client.
+   *
+   * This event comes before the function execution, so that if you return
+   * a different value from the original {@link IWrtnAgentEvent.ICall.arguments},
+   * you can modify the arguments of the function calling.
+   *
+   * Otherwise you do not return anything (`undefined`) or `null` value, the
+   * arguments of the function calling would not be modified. Also, if you are
+   * not interested in the function calling event, you can skit its
+   * implementation.
+   *
+   * @param evt Event of a function calling
+   * @return New arguments if you want to modify, otherwise null or undefined
+   */
+  call?(
+    evt: Primitive<IWrtnAgentEvent.ICall>,
+  ): Promise<object | null | undefined>;
+
+  /**
+   * Executition of a function.
+   *
+   * Informs a function execution from the AI agent server to client.
+   *
+   * @param evt Event of a function execution
+   */
+  execute?(evt: Primitive<IWrtnAgentEvent.IExecute>): Promise<void>;
+}

--- a/src/rpc/IWrtnAgentRpcService.ts
+++ b/src/rpc/IWrtnAgentRpcService.ts
@@ -1,0 +1,29 @@
+/**
+ * RPC interface of AI agent service.
+ *
+ * `IWrtnAgentRpcService` is an interface defining an AI agent service
+ * provided from the server to client through the RPC (Remote Procedure Call)
+ * paradigm in the websocket protocol.
+ *
+ * The client will call the {@link conversate} function remotely, and the
+ * server responses to the client by calling the client's
+ * {@link IWrtnAgentRpcListener} functions remotely too.
+ *
+ * @author Samchon
+ */
+export interface IWrtnAgentRpcService {
+  /**
+   * Conversate with the AI agent.
+   *
+   * User talks to the AI agent with the content.
+   *
+   * When AI agent responds some actions like conversating or executing
+   * LLM (Large Language Model) function calling, the functions defined in the
+   * {@link IWrtnAgentRpcListener} would be called through the RPC
+   * (Remote Procedure Call) paradigm.
+   *
+   * @param content The content to talk
+   * @returns Returned when the conversation process is completely done
+   */
+  conversate(content: string): Promise<void>;
+}

--- a/src/rpc/WrtnAgentRpcService.ts
+++ b/src/rpc/WrtnAgentRpcService.ts
@@ -1,0 +1,103 @@
+import { Primitive } from "typia";
+
+import { WrtnAgent } from "../WrtnAgent";
+import { IWrtnAgentRpcListener } from "./IWrtnAgentRpcListener";
+import { IWrtnAgentRpcService } from "./IWrtnAgentRpcService";
+
+/**
+ * RPC service for the {@link WrtnAgent}.
+ *
+ * `WrtnAgentRpcService` is class defining an AI agent service
+ * provided from the server to clients through the RPC (Remote Procedure Call)
+ * paradigm in the websocket protocol.
+ *
+ * Client connecting to the `WrtnAgentRpcService` providing websocket server
+ * will call the {@link conversate} function remotely through its basic
+ * interface type {@link IWrtnAgentRpcService} with the RPC paradigm.
+ *
+ * Also, the client provides the {@link IWrtnAgentRpcListener} type to the
+ * server, so that `WrtnAgentRpcService` will remotely call the
+ * {@link IWrtnAgentRpcListener listener}'s functions internally.
+ *
+ * You can open the WebSocket server of the AI agent like below:
+ *
+ * ```typescript
+ * import {
+ *   IWrtnAgentRpcListener,
+ *   IWrtnAgentRpcService,
+ *   WrtnAgent,
+ *   WrtnAgentRpcService,
+ * } from "@wrtnlabs/agent";
+ * import { WebSocketServer } from "tgrid";
+ *
+ * const server: WebSocketServer<
+ *   null,
+ *   IWrtnAgentRpcService,
+ *   IWrtnAgentRpcListener
+ * > = new WebSocketServer();
+ * await server.open(3001, async (acceptor) => {
+ *   await acceptor.accept(
+ *     new WrtnAgentRpcService({
+ *       agent: new WrtnAgent({ ... }),
+ *       listener: acceptor.getDriver(),
+ *     }),
+ *   );
+ * });
+ * ```
+ *
+ * @author Samchon
+ */
+export class WrtnAgentRpcService implements IWrtnAgentRpcService {
+  /**
+   * Initializer Constructor.
+   *
+   * @param props Properties to construct the RPC service
+   */
+  public constructor(private readonly props: WrtnAgentRpcService.IProps) {
+    const { agent, listener } = props;
+
+    // ESSENTIAL LISTENERS
+    agent.on("text", (evt) => listener.text(primitive(evt)));
+    agent.on("describe", (evt) => listener.describe(primitive(evt)));
+
+    // OPTIONAL LISTENERS
+    agent.on("select", (evt) => listener.select!(primitive(evt)));
+    agent.on("cancel", (evt) => listener.cancel!(primitive(evt)));
+    agent.on("call", async (evt) => {
+      const args: object | null | undefined = await listener.call!(
+        primitive(evt),
+      );
+      if (!!args) evt.arguments = args;
+    });
+    agent.on("execute", (evt) => listener.execute!(primitive(evt)));
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public async conversate(content: string): Promise<void> {
+    await this.props.agent.conversate(content);
+  }
+}
+export namespace WrtnAgentRpcService {
+  /**
+   * Properties of the {@link WrtnAgentRpcService}.
+   */
+  export interface IProps {
+    /**
+     * Target agent to provide as RPC service.
+     */
+    agent: WrtnAgent;
+
+    /**
+     * Listener to be binded on the agent.
+     */
+    listener: IWrtnAgentRpcListener;
+  }
+}
+
+/**
+ * @internal
+ */
+const primitive = <T>(obj: T): Primitive<T> =>
+  JSON.parse(JSON.stringify(obj)) as Primitive<T>;

--- a/test/examples/websocket.client.ts
+++ b/test/examples/websocket.client.ts
@@ -1,0 +1,22 @@
+import { IWrtnAgentRpcListener, IWrtnAgentRpcService } from "@wrtnlabs/agent";
+import { Driver, WebSocketConnector } from "tgrid";
+
+const main = async (): Promise<void> => {
+  const connector: WebSocketConnector<
+    null,
+    IWrtnAgentRpcListener,
+    IWrtnAgentRpcService
+  > = new WebSocketConnector(null, {
+    text: async (evt) => {
+      console.log(evt.role, evt.text);
+    },
+    describe: async (evt) => {
+      console.log("describer", evt.text);
+    },
+  });
+  await connector.connect("ws://localhost:3001");
+
+  const driver: Driver<IWrtnAgentRpcService> = connector.getDriver();
+  await driver.conversate("Hello, what you can do?");
+};
+main().catch(console.error);

--- a/test/examples/websocket.server.ts
+++ b/test/examples/websocket.server.ts
@@ -1,0 +1,37 @@
+import {
+  IWrtnAgentRpcListener,
+  IWrtnAgentRpcService,
+  WrtnAgent,
+  WrtnAgentRpcService,
+} from "@wrtnlabs/agent";
+import OpenAI from "openai";
+import { WebSocketServer } from "tgrid";
+
+import { TestGlobal } from "../TestGlobal";
+
+const main = async (): Promise<void> => {
+  const server: WebSocketServer<
+    null,
+    IWrtnAgentRpcService,
+    IWrtnAgentRpcListener
+  > = new WebSocketServer();
+  await server.open(3001, async (acceptor) => {
+    const agent = new WrtnAgent({
+      provider: {
+        api: new OpenAI({
+          apiKey: TestGlobal.env.CHATGPT_API_KEY,
+        }),
+        model: "gpt-4o-mini",
+        type: "chatgpt",
+      },
+      controllers: [],
+    });
+    await acceptor.accept(
+      new WrtnAgentRpcService({
+        agent,
+        listener: acceptor.getDriver(),
+      }),
+    );
+  });
+};
+main().catch(console.error);

--- a/test/features/resolve.ts
+++ b/test/features/resolve.ts
@@ -1,0 +1,4 @@
+const sum = (x: number, y: number) => (): Promise<number> =>
+  Promise.resolve(x + y);
+
+export const is = sum(1, 2);

--- a/test/features/resolve.ts
+++ b/test/features/resolve.ts
@@ -1,4 +1,0 @@
-const sum = (x: number, y: number) => (): Promise<number> =>
-  Promise.resolve(x + y);
-
-export const is = sum(1, 2);


### PR DESCRIPTION
This pull request introduces WebSocket communication capabilities to the `@wrtnlabs/agent` package, updates the package version, and adds new RPC-related modules. The most important changes include the addition of WebSocket communication examples, updates to the `package.json` file, and the creation of new RPC service and listener interfaces.

### WebSocket Communication

* Added a section in `README.md` explaining how to use the WebSocket interaction module provided by `@wrtnlabs/agent`, including code examples for both backend server and frontend application development.

### Package Updates

* Updated the package version in `package.json` from `0.1.0` to `0.2.0`.
* Added `tgrid` as a new dependency in `package.json`.

### RPC Modules

* Added new RPC-related modules to the `src` directory, including `IWrtnAgentRpcListener`, `IWrtnAgentRpcService`, and `WrtnAgentRpcService`. These modules define the interfaces and classes necessary for RPC communication between the AI agent and clients. [[1]](diffhunk://#diff-71ea73acdd23053804f08336a293db92d15b94fe0d1576718b980fef52f0385dR1-R112) [[2]](diffhunk://#diff-25417c62be66021f50e85229c5e62f69f62bc3faab1145a07abb4272fc032082R1-R29) [[3]](diffhunk://#diff-301cd8173845997a3cbdcc077664cdc119e56564ad845ed918f2391db800cac9R1-R103)

### Example Updates

* Added new example files `websocket.client.ts` and `websocket.server.ts` in the `test/examples` directory to demonstrate how to set up WebSocket communication using the new RPC modules. [[1]](diffhunk://#diff-594a9daef57c775049529179a5b68fed58f3754afde9cda198fef669881d00a5R1-R22) [[2]](diffhunk://#diff-a5ea18544c5c626bfa47aa7b6c78a16ff8463173632cc91d7221da9f9e1a2c6eR1-R37)

### Minor Changes

* Corrected the function call syntax in `README.md` for better readability.
* Updated links in the `README.md` to point to the correct test structure files.