### PR TITLE
Do not test LLM token required feature on Github Actions

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -46,7 +46,7 @@
   ],
   "devDependencies": {
     "@eslint/js": "^9.17.0",
-    "@nestia/e2e": "^0.8.0",
+    "@nestia/e2e": "^0.8.2",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^12.1.1",
     "@samchon/openapi": "^2.4.2",

--- a/packages/agent/test/features/test_base_event.ts
+++ b/packages/agent/test/features/test_base_event.ts
@@ -1,7 +1,11 @@
 import { WrtnAgent } from "@wrtnlabs/agent";
 import OpenAI from "openai";
 
-export async function test_base_event() {
+import { TestGlobal } from "../TestGlobal";
+
+export async function test_base_event(): Promise<void | false> {
+  if (!TestGlobal.env.CHATGPT_API_KEY) return false;
+
   // initialize count
   let initializeCount = 0;
   // text count
@@ -12,7 +16,7 @@ export async function test_base_event() {
     provider: {
       model: "gpt-4o-mini",
       api: new OpenAI({
-        apiKey: process.env.CHATGPT_API_KEY,
+        apiKey: TestGlobal.env.CHATGPT_API_KEY,
       }),
       type: "chatgpt",
     },
@@ -80,6 +84,4 @@ export async function test_base_event() {
   if ((textCount as number) !== 4) {
     throw new Error(`Text count should remain 4, but got ${textCount}`);
   }
-
-  return await Promise.resolve();
 }

--- a/packages/agent/test/features/test_base_websocket.ts
+++ b/packages/agent/test/features/test_base_websocket.ts
@@ -11,7 +11,11 @@ import { WebSocketConnector, WebSocketServer } from "tgrid";
 import { randint } from "tstl";
 import { Primitive } from "typia";
 
-export const test_base_websocket = async (): Promise<void> => {
+import { TestGlobal } from "../TestGlobal";
+
+export const test_base_websocket = async (): Promise<void | false> => {
+  if (!TestGlobal.env.CHATGPT_API_KEY) return false;
+
   const port: number = randint(30_001, 65_001);
   const server: WebSocketServer<
     null,
@@ -23,7 +27,7 @@ export const test_base_websocket = async (): Promise<void> => {
       provider: {
         model: "gpt-4o-mini",
         api: new OpenAI({
-          apiKey: process.env.CHATGPT_API_KEY,
+          apiKey: TestGlobal.env.CHATGPT_API_KEY,
         }),
         type: "chatgpt",
       },

--- a/packages/agent/test/features/test_base_work.ts
+++ b/packages/agent/test/features/test_base_work.ts
@@ -1,12 +1,16 @@
 import { IWrtnAgentPrompt, WrtnAgent } from "@wrtnlabs/agent";
 import OpenAI from "openai";
 
-export async function test_base_work() {
+import { TestGlobal } from "../TestGlobal";
+
+export async function test_base_work(): Promise<void | false> {
+  if (!TestGlobal.env.CHATGPT_API_KEY) return false;
+
   const agent: WrtnAgent = new WrtnAgent({
     provider: {
       model: "gpt-4o-mini",
       api: new OpenAI({
-        apiKey: process.env.CHATGPT_API_KEY,
+        apiKey: TestGlobal.env.CHATGPT_API_KEY,
       }),
       type: "chatgpt",
     },

--- a/packages/agent/test/features/test_benchmark_call.ts
+++ b/packages/agent/test/features/test_benchmark_call.ts
@@ -8,7 +8,9 @@ import path from "path";
 
 import { TestGlobal } from "../TestGlobal";
 
-export const test_benchmark_call = async (): Promise<void> => {
+export const test_benchmark_call = async (): Promise<void | false> => {
+  if (!TestGlobal.env.CHATGPT_API_KEY) return false;
+
   // HANDLESHAKE WITH SHOPPING BACKEND
   const connection: IHttpConnection = {
     host: "https://shopping-be.wrtn.ai",

--- a/packages/agent/test/features/test_benchmark_predicator.ts
+++ b/packages/agent/test/features/test_benchmark_predicator.ts
@@ -6,7 +6,6 @@ import {
   WrtnAgent,
 } from "@wrtnlabs/agent";
 import { WrtnAgentBenchmarkPredicator } from "@wrtnlabs/agent/lib/benchmark/common/WrtnAgentBenchmarkPredicator";
-import OpenAI from "openai";
 
 export const test_benchmark_predicator = async (): Promise<void> => {
   //----
@@ -15,9 +14,7 @@ export const test_benchmark_predicator = async (): Promise<void> => {
   const agent: WrtnAgent = new WrtnAgent({
     provider: {
       model: "gpt-4o-mini",
-      api: new OpenAI({
-        apiKey: process.env.CHATGPT_API_KEY,
-      }),
+      api: null!,
       type: "chatgpt",
     },
     controllers: [

--- a/packages/agent/test/features/test_benchmark_predicator_simple_allof.ts
+++ b/packages/agent/test/features/test_benchmark_predicator_simple_allof.ts
@@ -2,7 +2,6 @@ import { TestValidator } from "@nestia/e2e";
 import { HttpLlm, OpenApi } from "@samchon/openapi";
 import { IWrtnAgentOperation, WrtnAgent } from "@wrtnlabs/agent";
 import { WrtnAgentBenchmarkPredicator } from "@wrtnlabs/agent/lib/benchmark/common/WrtnAgentBenchmarkPredicator";
-import OpenAI from "openai";
 
 export const test_benchmark_predicator_simple_allof =
   async (): Promise<void> => {
@@ -12,9 +11,7 @@ export const test_benchmark_predicator_simple_allof =
     const agent: WrtnAgent = new WrtnAgent({
       provider: {
         model: "gpt-4o-mini",
-        api: new OpenAI({
-          apiKey: process.env.CHATGPT_API_KEY,
-        }),
+        api: null!,
         type: "chatgpt",
       },
       controllers: [

--- a/packages/agent/test/features/test_benchmark_select.ts
+++ b/packages/agent/test/features/test_benchmark_select.ts
@@ -10,7 +10,9 @@ import path from "path";
 
 import { TestGlobal } from "../TestGlobal";
 
-export const test_benchmark_select = async (): Promise<void> => {
+export const test_benchmark_select = async (): Promise<void | false> => {
+  if (!TestGlobal.env.CHATGPT_API_KEY) return false;
+
   const agent: WrtnAgent = new WrtnAgent({
     provider: {
       model: "gpt-4o-mini",

--- a/packages/agent/test/index.ts
+++ b/packages/agent/test/index.ts
@@ -4,10 +4,6 @@ import chalk from "chalk";
 import { TestGlobal } from "./TestGlobal";
 
 const main = async (): Promise<void> => {
-  if (!TestGlobal.env.CHATGPT_API_KEY?.length) {
-    throw new Error("environments CHATGPT_API_KEY is not set");
-  }
-
   // DO TEST
   const include: string[] = TestGlobal.getArguments("include");
   const exclude: string[] = TestGlobal.getArguments("exclude");
@@ -15,10 +11,11 @@ const main = async (): Promise<void> => {
     prefix: "test_",
     location: __dirname + "/features",
     parameters: () => [],
-    onComplete: (exec) => {
+    onComplete: (exec: DynamicExecutor.IExecution) => {
       const trace = (str: string) =>
         console.log(`  - ${chalk.green(exec.name)}: ${str}`);
-      if (exec.error === null) {
+      if (exec.value === false) trace(chalk.gray("Pass"));
+      else if (exec.error === null) {
         const elapsed: number =
           new Date(exec.completed_at).getTime() -
           new Date(exec.started_at).getTime();


### PR DESCRIPTION
This pull request includes several changes to the `packages/agent` module, primarily focusing on updating dependencies and improving the test suite by handling missing API keys more gracefully. The most important changes include updating the `@nestia/e2e` dependency version, modifying test functions to check for the presence of `CHATGPT_API_KEY`, and removing the OpenAI import in some test files.

### Dependency Update:
* [`packages/agent/package.json`](diffhunk://#diff-f0f4adde46deb8e106c88cfb5dbf48155b8261ff0d73ada3429381a40e9bb3baL49-R49): Updated `@nestia/e2e` dependency from version `^0.8.0` to `^0.8.2`.

### Test Suite Improvements:
* [`packages/agent/test/features/test_base_event.ts`](diffhunk://#diff-7ce7c8826565128d36a365860f016aa1010ed7ab28976f97ef5b0a2da1d61072L4-R8): Modified `test_base_event` function to check for `CHATGPT_API_KEY` in `TestGlobal.env` and return `false` if not present. Updated the API key reference to use `TestGlobal.env.CHATGPT_API_KEY`. [[1]](diffhunk://#diff-7ce7c8826565128d36a365860f016aa1010ed7ab28976f97ef5b0a2da1d61072L4-R8) [[2]](diffhunk://#diff-7ce7c8826565128d36a365860f016aa1010ed7ab28976f97ef5b0a2da1d61072L15-R19) [[3]](diffhunk://#diff-7ce7c8826565128d36a365860f016aa1010ed7ab28976f97ef5b0a2da1d61072L83-L84)
* [`packages/agent/test/features/test_base_websocket.ts`](diffhunk://#diff-32b0c2f3ae3981e64575b54fadaae8f94efa3360679ef7460ede8e677ead46b6L14-R18): Modified `test_base_websocket` function to check for `CHATGPT_API_KEY` in `TestGlobal.env` and return `false` if not present. Updated the API key reference to use `TestGlobal.env.CHATGPT_API_KEY`. [[1]](diffhunk://#diff-32b0c2f3ae3981e64575b54fadaae8f94efa3360679ef7460ede8e677ead46b6L14-R18) [[2]](diffhunk://#diff-32b0c2f3ae3981e64575b54fadaae8f94efa3360679ef7460ede8e677ead46b6L26-R30)
* [`packages/agent/test/features/test_base_work.ts`](diffhunk://#diff-9981e2b53d4f534169e469a804d3f18f7f5d29e10e4c47e25f03be5522ca104fL4-R13): Modified `test_base_work` function to check for `CHATGPT_API_KEY` in `TestGlobal.env` and return `false` if not present. Updated the API key reference to use `TestGlobal.env.CHATGPT_API_KEY`.
* [`packages/agent/test/features/test_benchmark_call.ts`](diffhunk://#diff-e449644ae1aae455b8f78c2be56185a32cfc3160de6f91d21482de350e6ce190L11-R13): Modified `test_benchmark_call` function to check for `CHATGPT_API_KEY` in `TestGlobal.env` and return `false` if not present.
* [`packages/agent/test/features/test_benchmark_predicator.ts`](diffhunk://#diff-d961dbd52ca9d13de1b1797c557bea65b98e11c23dfcb34a673fd78835212cf7L9): Removed the OpenAI import and set the `api` field to `null!` in the `test_benchmark_predicator` function. [[1]](diffhunk://#diff-d961dbd52ca9d13de1b1797c557bea65b98e11c23dfcb34a673fd78835212cf7L9) [[2]](diffhunk://#diff-d961dbd52ca9d13de1b1797c557bea65b98e11c23dfcb34a673fd78835212cf7L18-R17)
* [`packages/agent/test/features/test_benchmark_predicator_simple_allof.ts`](diffhunk://#diff-b4025cb2d4f34d633f1f1dff82bba3eca4f8cece8f38cf4ee586556beab5fd36L5): Removed the OpenAI import and set the `api` field to `null!` in the `test_benchmark_predicator_simple_allof` function. [[1]](diffhunk://#diff-b4025cb2d4f34d633f1f1dff82bba3eca4f8cece8f38cf4ee586556beab5fd36L5) [[2]](diffhunk://#diff-b4025cb2d4f34d633f1f1dff82bba3eca4f8cece8f38cf4ee586556beab5fd36L15-R14)
* [`packages/agent/test/features/test_benchmark_select.ts`](diffhunk://#diff-192f3a2182c8e5bf8d2891ef31e90e49c208d110ce53a01b45b9ea29256cfba4L13-R15): Modified `test_benchmark_select` function to check for `CHATGPT_API_KEY` in `TestGlobal.env` and return `false` if not present.
* [`packages/agent/test/index.ts`](diffhunk://#diff-68781a51c6288bab9052e254d007a5381091fb287afb27598721d65ec4ae707eL7-R18): Removed the initial check for `CHATGPT_API_KEY` and added handling for test functions returning `false` to indicate a pass.